### PR TITLE
Moves controller generate into after bundle

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -26,8 +26,6 @@ def apply_template
   copy_file 'app/controllers/application_controller.rb', force: true
   copy_file 'app/assets/stylesheets/layout.css.erb', force: true
 
-  generate(:controller, 'static home')
-
   copy_file 'app/controllers/users/omniauth_callbacks_controller.rb'
 
   create_file 'Procfile' do
@@ -43,6 +41,7 @@ def apply_template
   create_file '.env'
 
   after_bundle do
+    generate(:controller, 'static home')
     devise_user
     add_routes
     add_tests


### PR DESCRIPTION
Trying to generate a controller before bundle would fail if the
bundle dependencies weren't accidentally available already due to
previous runs. That was not :rainbow:.